### PR TITLE
Fix: Follow System Theme on app startup

### DIFF
--- a/src/main/app/index.js
+++ b/src/main/app/index.js
@@ -249,10 +249,9 @@ class App {
     nativeTheme.themeSource = 'system'
 
     // Apply theme at startup if "Follow system theme" is enabled
-    const isDarkTheme = /dark/i.test(theme)
     const systemIsDark = nativeTheme.shouldUseDarkColors
 
-    if (followSystemTheme && isDarkTheme !== systemIsDark) {
+    if (followSystemTheme) {
       const newTheme = systemIsDark ? darkModeTheme : lightModeTheme
       log.info(
         `Following system theme at startup: ${newTheme} (system ${systemIsDark ? 'dark' : 'light'})`


### PR DESCRIPTION
The system theme is not followed when the app is launched, you have to enable/disable the "follow system theme" switch. 
This should fix that problem.